### PR TITLE
Filter elections by authority

### DIFF
--- a/src/pages/ElectionAuthority.tsx
+++ b/src/pages/ElectionAuthority.tsx
@@ -109,6 +109,7 @@ const ElectionAuthority = () => {
       </div>
       <ElectionAuthorityDashboard
         electionId={selectedElectionId}
+        authorityId={authorityId!}
         onLogout={handleLogout}
       />
     </div>


### PR DESCRIPTION
## Summary
- pass authority ID to ElectionAuthorityDashboard
- filter Supabase elections by `authority_id`
- show error when selected election isn't owned by authority

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b99e50984c832da84cdc3c873a5bb7